### PR TITLE
Install python packages for Airflow before installing Airflow.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -20,7 +20,7 @@ description      'Installs and configures Airflow workflow management platform.'
 long_description 'Installs and configures Airflow workflow management platform. More information about Airflow can be found here: https://github.com/airbnb/airflow'
 source_url       'https://github.com/bahchis/airflow-cookbook'
 issues_url       'https://github.com/bahchis/airflow-cookbook/issues'
-version          '1.1.5'
+version          '1.1.6'
 supports         'ubuntu', '>= 14.04'
 supports         'centos', '>= 7.0'
 

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -57,23 +57,6 @@ dependencies_to_install.each do |value|
   end
 end
 
-# Get Airflow package name based on version
-airflow_pkg = if node['airflow']['version'] && node['airflow']['version'] < '1.8.1'
-                'airflow'
-              else
-                'apache-airflow'
-              end
-
-log 'message' do
-  message 'Airflow package name identified as ' + airflow_pkg + ' based on version requirement: ' + node['airflow']['version']
-  level :info
-end
-
-# Install Airflow
-python_package airflow_pkg do
-  version node['airflow']['version']
-end
-
 # Install Airflow packages
 node['airflow']['packages'].each do |_key, value|
   value.each do |val|
@@ -91,4 +74,21 @@ node['airflow']['packages'].each do |_key, value|
       version version_to_install.to_s
     end
   end
+end
+
+# Get Airflow package name based on version
+airflow_pkg = if node['airflow']['version'] && node['airflow']['version'] < '1.8.1'
+                'airflow'
+              else
+                'apache-airflow'
+              end
+
+log 'message' do
+  message 'Airflow package name identified as ' + airflow_pkg + ' based on version requirement: ' + node['airflow']['version']
+  level :info
+end
+
+# Install Airflow
+python_package airflow_pkg do
+  version node['airflow']['version']
 end


### PR DESCRIPTION
Small change to install Airflow dependencies before installing Airflow. This reduces the potential for the Airflow install to timeout.